### PR TITLE
Add build workflow using Github actions

### DIFF
--- a/.github/workflows/ant.yml
+++ b/.github/workflows/ant.yml
@@ -1,0 +1,65 @@
+name: Java CI
+
+on:
+  push:
+    branches:
+      - master
+  schedule:
+    # Every day at 3am
+    - cron: '0 3 * * *'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: 'recursive'
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+
+    - name: Setup WALA
+      run: ./setup_deps
+    - name: Build with Ant
+      run: ant -noinput -buildfile build.xml
+
+    - uses: actions/upload-artifact@v2
+      with:
+        name: joana.api.jar
+        path: ./dist/joana.api.jar
+    - uses: actions/upload-artifact@v2
+      with:
+        name: joana.ifc.sdg.core.jar
+        path: ./dist/joana.ifc.sdg.core.jar
+    - uses: actions/upload-artifact@v2
+      with:
+        name: joana.ifc.sdg.qifc.nildumu.jar
+        path: ./dist/joana.ifc.sdg.qifc.nildumu.jar
+    - uses: actions/upload-artifact@v2
+      with:
+        name: joana.ui.ifc.sdg.graphviewer.jar
+        path: ./dist/joana.ui.ifc.sdg.graphviewer.jar
+    - uses: actions/upload-artifact@v2
+      with:
+        name: joana.ui.ifc.wala.cli.jar
+        path: ./dist/joana.ui.ifc.wala.cli.jar
+    - uses: actions/upload-artifact@v2
+      with:
+        name: joana.ui.ifc.wala.console.jar
+        path: ./dist/joana.ui.ifc.wala.console.jar
+    - uses: actions/upload-artifact@v2
+      with:
+        name: joana.wala.core.jar
+        path: ./dist/joana.wala.core.jar
+    - uses: actions/upload-artifact@v2
+      with:
+        name: joana.wala.dictionary.jar
+        path: ./dist/joana.wala.dictionary.jar
+    - uses: actions/upload-artifact@v2
+      with:
+        name: joana.wala.jodroid.jar
+        path: ./dist/joana.wala.jodroid.jar

--- a/.github/workflows/remove-old-artifacts.yml
+++ b/.github/workflows/remove-old-artifacts.yml
@@ -1,0 +1,21 @@
+name: Remove old artifacts
+
+on:
+  push:
+    branches:
+      - master
+  schedule:
+    # Every day at 4am
+    - cron: '0 4 * * *'
+
+jobs:
+  remove-old-artifacts:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+    - name: Remove old artifacts
+      uses: c-hive/gha-remove-artifacts@v1
+      with:
+        age: '1 day'
+        skip-tags: true


### PR DESCRIPTION
I created a build workflow using the free Github actions that executes the build after every push to master and at one time at night. It stores the generated JARs as part of the build logs and deletes old files after one day. It is useful to ensure that the build descriptions are up to date and the application can always be built from the sources.

It certainly misses a proper deployment but this would require choosing a deployment destination and providing credentials. Anyway, it might be useful for you as a starting point for a more elaborated workflow. If not, feel free to close the pull request.